### PR TITLE
Remove nonexistent sdl2_image homebrew option

### DIFF
--- a/graphics_setup.sh
+++ b/graphics_setup.sh
@@ -10,7 +10,7 @@ case `uname` in
 	brew install sdl2
 	brew install sdl2_mixer
 	brew install sdl2_ttf
-	brew install sdl2_image --without-webp
+	brew install sdl2_image
         brew install sdl2_gfx
 	;;
     Linux)


### PR DESCRIPTION
This PR avoids a warning output by the preparatory script.

> Warning: sdl2_image: this formula has no --without-webp option so it will be ignored!