### PR TITLE
Fix script output typo.

### DIFF
--- a/graphics_setup.sh
+++ b/graphics_setup.sh
@@ -25,7 +25,7 @@ case "$(uname -s)" in
 
             $sudo apt-get install --no-install-recommends --no-install-suggests libsdl1.2-dev libsdl-image1.2-dev libsdl-mixer1.2-dev libsdl-ttf2.0-dev gcc g++
         else
-            echo "Detected macOS but not apt. Install sdl2 with your package manager."
+            echo "Detected Linux but not apt. Install sdl2 with your package manager."
             exit 1
         fi
         ;;


### PR DESCRIPTION
Oops, I just noticed my mistake. It should be "Linux" not "macOS" in the `echo` output here. Sorry about that!